### PR TITLE
Pgodfrey/waypoint updater

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -36,10 +36,7 @@ class WaypointUpdater(object):
 
         # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
 
-
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
-
-        self.count = 0;
 
         # TODO: Add other member variables you need below
         self.update()


### PR DESCRIPTION
This code will pull in a list of track waypoints, find the nearest waypoint, and publish a list of the next N waypoints to /final_endpoint. Once this is merged in it's possible to start work on the PID controller as you'll have a list of waypoints to follow.

Details:

- Subscribed to /base_waypoints to grab the full list of track waypoints. After the list is grabbed via the waypoints_cb we unsubscribe because the list doesn't change so no point in polling.
- Update method fires at every interval and finds the nearest waypoint (find_nearest_endpoint()) by calculating the euclidian distance (calculate_distance()) between the cars current state and the base waypoint stored in self.current_waypoints. 
- Publish the next N waypoints from the nearest waypoint to /final_waypoints via publish_next_waypoints method