### PR TITLE
control steering in simulator

### DIFF
--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,3 +1,6 @@
+from pid import PID
+from lowpass import LowPassFilter
+from yaw_controller import YawController
 
 GAS_DENSITY = 2.858
 ONE_MPH = 0.44704
@@ -6,9 +9,30 @@ ONE_MPH = 0.44704
 class Controller(object):
     def __init__(self, *args, **kwargs):
         # TODO: Implement
-        pass
+        vehicle_mass = kwargs['vehicle_mass']
+        fuel_capacity = kwargs['fuel_capacity']
+        brake_deadband = kwargs['brake_deadband']
+        decel_limit = kwargs['decel_limit']
+        accel_limit = kwargs['accel_limit']
+        wheel_radius = kwargs['wheel_radius']
+        wheel_base = kwargs['wheel_base']
+        steer_ratio = kwargs['steer_ratio']
+        max_lat_accel = kwargs['max_lat_accel']
+        max_steer_angle = kwargs['max_steer_angle']
+        min_speed = 10
+
+        params = [wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle]
+        self.yaw_controller = YawController(*params)
 
     def control(self, *args, **kwargs):
         # TODO: Change the arg, kwarg list to suit your needs
         # Return throttle, brake, steer
-        return 1., 0., 0.
+        linear_setpoint = kwargs['linear_setpoint']
+        angular_setpoint = kwargs['angular_setpoint']
+        linear_current = kwargs['linear_current']
+
+        throttle = 0.5
+        brake = 0.
+        steer = self.yaw_controller.get_steering(linear_setpoint, angular_setpoint, linear_current)
+
+        return throttle, brake, steer


### PR DESCRIPTION
This will initialize the yaw controller with the necessary vehicle params (wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle) and then process twist commands coming from the pure pursuit module to adjust the steering wheel via yaw_controller.get_steering() before passing throttle, brake, and steer back to the dbw node. Car can now complete laps around the simulator.

Note: For this initial work I just used a static throttle and brake of 0 in order to focus on wiring up the steering. 